### PR TITLE
Fix a minor bug in the caesar algorithm

### DIFF
--- a/src/classic_algorithms/caesar.js
+++ b/src/classic_algorithms/caesar.js
@@ -38,12 +38,12 @@ function caesarCipher(message, alphabet, n_rotation) {
         nomenclator[alphabet[i]] = cipheredAlphabet[i]
     }
 
-    const messageToCipher = message.trim().replace(' ', '').trim();
+    const messageToCipher = message.trim().replaceAll(' ', '').trim();
     for (index in messageToCipher) {
         cipheredMessage += nomenclator[messageToCipher[index]]
     }
 
-    if (cipheredMessage.length != message.trim().replace(' ', '').length) {
+    if (cipheredMessage.length != message.trim().replaceAll(' ', '').length) {
         throw new Error('caesarCipher() Internal Error: Something wrong has happened when ciphering the message: length of both, ciphered and original message is not the same')
     }
 


### PR DESCRIPTION
replace replace() for replaceAll(). The first function just change the first character found, whereas the second one changes all characters that follows the regex proposed